### PR TITLE
feat(ci): Add reviewdog implementation

### DIFF
--- a/.github/workflows/lint-changelog.yaml
+++ b/.github/workflows/lint-changelog.yaml
@@ -3,11 +3,13 @@ name: Changelog Linter
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   lint-changelog:
     runs-on: ubuntu-latest
-    permissions:
-      actions: write
 
     steps:
     - name: Check out the repository

--- a/.github/workflows/lint-changelog.yaml
+++ b/.github/workflows/lint-changelog.yaml
@@ -16,7 +16,6 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run changelog linter
-      # uses: MalteHerrmann/changelog-lint-action@135186f4c4e9d20424a5334c13ea749f601195b1
       uses: ./
       with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-changelog.yaml
+++ b/.github/workflows/lint-changelog.yaml
@@ -12,5 +12,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run changelog linter
-      uses: MalteHerrmann/changelog-lint-action@135186f4c4e9d20424a5334c13ea749f601195b1
+      # uses: MalteHerrmann/changelog-lint-action@135186f4c4e9d20424a5334c13ea749f601195b1
+      uses: ./
+      with:
+          github_token: ${{ secrets.github_token }}
+
 

--- a/.github/workflows/lint-changelog.yaml
+++ b/.github/workflows/lint-changelog.yaml
@@ -12,5 +12,5 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run changelog linter
-      uses: MalteHerrmann/changelog-lint-action@0918ef12e6dc06adce0743e1c6c13707a7c20323
+      uses: MalteHerrmann/changelog-lint-action@135186f4c4e9d20424a5334c13ea749f601195b1
 

--- a/.github/workflows/lint-changelog.yaml
+++ b/.github/workflows/lint-changelog.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   lint-changelog:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
 
     steps:
     - name: Check out the repository
@@ -15,6 +17,6 @@ jobs:
       # uses: MalteHerrmann/changelog-lint-action@135186f4c4e9d20424a5334c13ea749f601195b1
       uses: ./
       with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,5 @@ This changelog was created using the `clu` binary
 
 ### Features
 
-- (ci) [#2](https://github.com/MalteHerrmann/changelog-lint-action/pull/2) add reviewdog to have PR review comments available.
+- (ci) [#2](https://github.com/MalteHerrmann/changelog-lint-action/pull/2) Add reviewdog to post PR review comments.
 - (ci) [#1](https://github.com/MalteHerrmann/changelog-lint-action/pull/1) Add action implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ This changelog was created using the `clu` binary
 
 ### Features
 
+- (ci) [#2](https://github.com/MalteHerrmann/changelog-lint-action/pull/2) add reviewdog to have PR review comments available.
 - (ci) [#1](https://github.com/MalteHerrmann/changelog-lint-action/pull/1) Add action implementation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM ghcr.io/malteherrmann/changelog-utils:latest
 
 WORKDIR /github/workspace
 
-CMD ["lint"]
+COPY entrypoint.sh .
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Changelog Lint Action
+
+This GitHub action brings the linter from the [changelog-utils](https://github.com/MalteHerrmann/changelog-utils)
+to your CI workflows.
+
+It's using [reviewdog](https://github.com/reviewdog/reviewdog) to post comments on PR reviews that show any potential
+problems with your changelogs.

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: 'Changelog Linter'
 description: 'A linter for your changelog. Based on https://github.com/MalteHerrmann/changelog-utils'
 author: 'Malte Herrmann'
+inputs:
+  github_token:
+    description: 'GITHUB_TOKEN'
+    default: '${{ github.token }}'
 outputs:
   linter-results:
     description: 'Changelog linter output'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -ex
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 clu lint | reviewdog -efm="%f:%l: %m" \
-      -name="linter-name (clu)" \
+      -name="clu" \
       -reporter="github-pr-review" \
       -filter-mode="nofilter" \
       -fail-on-error="true"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+
+clu lint | reviewdog -efm="%f:%l: %m" \
+      -name="linter-name (clu)" \
+      -reporter="github-pr-review"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,5 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 clu lint | reviewdog -efm="%f:%l: %m" \
       -name="linter-name (clu)" \
       -reporter="github-pr-review" \
-      -filter-mode="nofilter"
+      -filter-mode="nofilter" \
+      -fail-on-error="true"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -ex
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 clu lint | reviewdog -efm="%f:%l: %m" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,5 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 clu lint | reviewdog -efm="%f:%l: %m" \
       -name="linter-name (clu)" \
-      -reporter="github-pr-review"
+      -reporter="github-pr-review" \
+      -filter-mode="nofilter"


### PR DESCRIPTION
This PR adds the functionality of the latest [clu](https://github.com/MalteHerrmann/changelog-utils) release, which enables using [reviewdog](https://github.com/reviewdog/reviewdog) to add review comments for available linter warnings.