### PR TITLE
imp(docker): Pin clu version in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- (docker) [#5](https://github.com/MalteHerrmann/changelog-lint-action/pull/5) Pin clu version in Dockerfile.
+
 ## [v0.1.0](https://github.com/MalteHerrmann/changelog-lint-action/releases/tag/v0.1.0) - 2024-06-30
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/malteherrmann/changelog-utils:latest
+FROM ghcr.io/malteherrmann/changelog-utils:v1.1.2
 
 WORKDIR /github/workspace
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,29 @@ to your CI workflows.
 
 It's using [reviewdog](https://github.com/reviewdog/reviewdog) to post comments on PR reviews that show any potential
 problems with your changelogs.
+
+## Example Workflow
+
+```yaml
+name: Changelog Linter
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  lint-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+
+    - name: Run changelog linter
+      uses: MalteHerrmann/changelog-lint-action@v0.1.0
+      with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+```


### PR DESCRIPTION
This PR pins the version of the `clu` base image that is used in the GitHub action.
