### PR TITLE
imp(docker): Use clu v1.2.0 and prepare v0.2.0 release of action

### DIFF
--- a/.clconfig.json
+++ b/.clconfig.json
@@ -4,9 +4,9 @@
     "docker"
   ],
   "change_types": {
-    "Bug Fixes": "bug\\s*fixes",
-    "Features": "features",
-    "Improvements": "improvements"
+    "Bug Fixes": "fix",
+    "Features": "feat",
+    "Improvements": "imp"
   },
   "expected_spellings": {},
   "legacy_version": null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
-## Unreleased
+## [v0.2.0](https://github.com/MalteHerrmann/changelog-lint-action/releases/tag/v0.2.0) - 2024-08-03
 
 ### Improvements
 
+- (docker) [#7](https://github.com/MalteHerrmann/changelog-lint-action/pull/7) Use clu v1.2.0 and prepare v0.2.0 release of action.
 - (docker) [#5](https://github.com/MalteHerrmann/changelog-lint-action/pull/5) Pin clu version in Dockerfile.
 
 ## [v0.1.0](https://github.com/MalteHerrmann/changelog-lint-action/releases/tag/v0.1.0) - 2024-06-30

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/malteherrmann/changelog-utils:v1.1.2
+FROM ghcr.io/malteherrmann/changelog-utils:v1.2.0
 
 WORKDIR /github/workspace
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run changelog linter
-      uses: MalteHerrmann/changelog-lint-action@v0.1.0
+      uses: MalteHerrmann/changelog-lint-action@v0.2.0
       with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
This PR bumps the `clu` version to v1.2.0 and prepares the v0.2.0 release of this action.