### PR TITLE
imp(docker): Update changelog-utils to v1.5.0 and prepare v0.3.0 release

### DIFF
--- a/.clconfig.json
+++ b/.clconfig.json
@@ -3,11 +3,22 @@
     "ci",
     "docker"
   ],
-  "change_types": {
-    "Bug Fixes": "fix",
-    "Features": "feat",
-    "Improvements": "imp"
-  },
+  "change_types": [
+    {
+      "long": "Features",
+      "short": "feat"
+    },
+    {
+      "long": "Improvements",
+      "short": "imp"
+    },
+    {
+      "long": "Bug Fixes",
+      "short": "fix"
+    }
+  ],
+  "changelog_path": "./CHANGELOG.md",
+  "commit_message": "add changelog entry",
   "expected_spellings": {},
   "legacy_version": null,
   "target_repo": "https://github.com/MalteHerrmann/changelog-lint-action"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- (docker) [#9](https://github.com/MalteHerrmann/changelog-lint-action/pull/9) Update changelog-utils to v1.5.0 and prepare v0.3.0 release.
+
 ## [v0.2.1](https://github.com/MalteHerrmann/changelog-lint-action/releases/tag/v0.2.1) - 2024-10-26
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
-## Unreleased
+## [v0.3.0](https://github.com/MalteHerrmann/changelog-lint-action/releases/tag/v0.3.0) - 2025-05-21
 
 ### Improvements
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/malteherrmann/changelog-utils:v1.2.0
+FROM ghcr.io/malteherrmann/changelog-utils:v1.5.0
 
 WORKDIR /github/workspace
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run changelog linter
-      uses: MalteHerrmann/changelog-lint-action@v0.2.1
+      uses: MalteHerrmann/changelog-lint-action@v0.3.0
       with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
This PR updates the Docker base image to use changelog-utils v1.5.0 (from v1.2.0) and updates the recommended action version in the README to v0.3.0.

Additionally, it restructures the change_types configuration in .clconfig.json from an object to an array of objects with long and short forms, and adds the changelog_path and commit_message fields.