### PR TITLE
imp(all): Update changelog-utils to v1.6.1 and introduce check-diff command; prepare v0.5.0

### DIFF
--- a/.github/workflows/lint-changelog.yaml
+++ b/.github/workflows/lint-changelog.yaml
@@ -1,4 +1,4 @@
-name: Changelog Linter
+name: Changelog Utils
 
 on:
   pull_request:
@@ -8,12 +8,17 @@ permissions:
   contents: read
 
 jobs:
-  lint-changelog:
+  check-changelog:
     runs-on: ubuntu-latest
 
     steps:
     - name: Check out the repository
       uses: actions/checkout@v4
+
+    - name: Check diff
+      uses: ./
+      with:
+          command: check-diff
 
     - name: Run changelog linter
       uses: ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/malteherrmann/changelog-utils:v1.6.0
+FROM ghcr.io/malteherrmann/changelog-utils:v1.6.1
 
 WORKDIR /github/workspace
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
-# Changelog Lint Action
+# Changelog Utils Action
 
-This GitHub action brings the linter from the [changelog-utils](https://github.com/MalteHerrmann/changelog-utils)
+This GitHub action brings the [changelog-utils](https://github.com/MalteHerrmann/changelog-utils)
 to your CI workflows.
 
 It's using [reviewdog](https://github.com/reviewdog/reviewdog) to post comments on PR reviews that show any potential
 problems with your changelogs.
 
+## Supported Utils
+
+Currently, the CI action supports:
+
+- `clu lint`
+- `clu check-diff`
+
 ## Example Workflow
+
+### Linter
 
 ```yaml
 name: Changelog Linter
@@ -26,8 +35,15 @@ jobs:
     - name: Check out the repository
       uses: actions/checkout@v4
 
+    - name: Check changelog diff
+      uses: MalteHerrmann/changelog-utils-action@v0.5.0
+      with:
+          command: check-diff
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Run changelog linter
       uses: MalteHerrmann/changelog-lint-action@v0.4.0
       with:
+          command: lint
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,16 @@
-name: 'Changelog Linter'
-description: 'A linter for your changelog. Based on https://github.com/MalteHerrmann/changelog-utils'
+name: 'Changelog Utils'
+description: 'A collection of utilities for your changelog. Based on https://github.com/MalteHerrmann/changelog-utils'
 author: 'Malte Herrmann'
 inputs:
+  command:
+    description: 'Which changelog utility to use?'
+    default: 'lint'
   github_token:
     description: 'GITHUB_TOKEN'
     default: '${{ github.token }}'
 outputs:
-  linter-results:
-    description: 'Changelog linter output'
+  util-results:
+    description: 'Changelog utility output'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,15 @@ set -ex
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-clu lint | reviewdog -efm="%f:%l: %m" \
-  -name="changelog-lint" \
-  -reporter="github-pr-review" \
-  -filter-mode="nofilter" \
-  -fail-on-error="true"
+if [ "$INPUT_COMMAND" = "lint" ]; then
+  clu "$INPUT_COMMAND" | reviewdog -efm="%f:%l: %m" \
+    -name="changelog-utils" \
+    -reporter="github-pr-review" \
+    -filter-mode="nofilter" \
+    -fail-on-error="true"
+elif [ "$INPUT_COMMAND" = "check-diff" ]; then
+  clu "$INPUT_COMMAND"
+else
+  echo "Error: Invalid command '$INPUT_COMMAND'. Valid options are 'lint' or 'check-diff'." >&2
+  exit 1
+fi


### PR DESCRIPTION
This PR updates `clu` to v1.6.1 and introduces support for using the `check-diff` subcommand in the CI action as well.
This also comes with renaming the action to avoid the "linter" naming and generalize it.

Furthermore, I'm preparing v0.5.0 here.
